### PR TITLE
add 500 error email middleware

### DIFF
--- a/apps/web/backend/index.js
+++ b/apps/web/backend/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const connectToMongo = require('./db');
 const cors = require('cors');
+const handleError = require('./middleware/error');
 
 const load = async () => {
     await connectToMongo();
@@ -10,6 +11,7 @@ const load = async () => {
     
     app.use(express.json());
     app.use(cors());
+
     
     // Available Routes
     app.use('/api/auth', require('./routes/auth'));
@@ -19,6 +21,9 @@ const load = async () => {
     app.get('/', (req, res) => {
         res.send('Hi!');
     });
+    
+    // Error handling middleware
+    app.use(handleError);
     
     app.listen(PORT, () => {
         console.log(`The App is running at http://localhost:${PORT}`);

--- a/apps/web/backend/middleware/error.js
+++ b/apps/web/backend/middleware/error.js
@@ -1,4 +1,6 @@
 const nodemailer = require('nodemailer');
+const outlookEmail = process.env.outlookEmail;
+const outlookPassword = process.env.outlookPassword;
 
 const handleError = (err, req, res, next) => {
     console.error(err.stack);
@@ -9,18 +11,16 @@ const handleError = (err, req, res, next) => {
 
     if (statusCode === 500) {
     const transporter = nodemailer.createTransport({
-        host: 'smtp.gmail.com',
-        port: 587,
-        secure: false,
+        service: 'hotmail',
         auth: {
-        user: 'sender@gmail.com',
-        pass: 'senderpassword'
+            user: outlookEmail,
+            pass: outlookPassword
         }
     });
 
     const mailOptions = {
-        from: 'sender@gmail.com',
-        to: 'receiver@gmail.com',
+        from: outlookEmail,
+        to: outlookEmail,
         subject: `Important!! : ${message}`,
         text: `Stack Trace:\n${err.stack}`
     };

--- a/apps/web/backend/middleware/error.js
+++ b/apps/web/backend/middleware/error.js
@@ -1,0 +1,39 @@
+const nodemailer = require('nodemailer');
+
+const handleError = (err, req, res, next) => {
+    console.error(err.stack);
+    const statusCode = err.statusCode || 500;
+    const message = err.message || 'Internal Server Error';
+
+    console.log("Send message")
+
+    if (statusCode === 500) {
+    const transporter = nodemailer.createTransport({
+        host: 'smtp.gmail.com',
+        port: 587,
+        secure: false,
+        auth: {
+        user: 'sender@gmail.com',
+        pass: 'senderpassword'
+        }
+    });
+
+    const mailOptions = {
+        from: 'sender@gmail.com',
+        to: 'receiver@gmail.com',
+        subject: `Important!! : ${message}`,
+        text: `Stack Trace:\n${err.stack}`
+    };
+
+    transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+        console.error(error);
+        } else {
+        console.log(`Email sent: ${info.response}`);
+        }
+    });
+    }
+    res.status(statusCode).send(message);
+}
+
+module.exports = handleError;


### PR DESCRIPTION
## Describe your changes

Added a middleware to send email to send email to admin in case of `500 server error`

## Screenshots - If Any (Optional)
![image](https://user-images.githubusercontent.com/65801700/220278474-3316bf61-1f5a-4427-99ec-82f3f813c20f.png)


## Issue ticket number and link - If Any
#215 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](https://github.com/dvstechlabs/Noteslify/blob/main/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

## Additional Information (Optional)
The following details for the `nodemailer` configuration needs to be updated with admin details : 
![error js-2023-02-21-13-02-04](https://user-images.githubusercontent.com/65801700/220279204-994081cd-7e62-4741-9e87-8c7e074b1c83.png)
![error js-2023-02-21-13-02-34](https://user-images.githubusercontent.com/65801700/220279221-a1645164-6a79-4435-8cf2-80ed17ff2616.png)

